### PR TITLE
fix: compatibility between docker go client and docker engine

### DIFF
--- a/BashoBench.go
+++ b/BashoBench.go
@@ -35,7 +35,7 @@ func runBashoBench(configPath string) error {
 		return  err
 	}
 
-	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
 
 	if err != nil {
 		return  err

--- a/BashoBench.go
+++ b/BashoBench.go
@@ -35,7 +35,7 @@ func runBashoBench(configPath string) error {
 		return  err
 	}
 
-	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
 
 	if err != nil {
 		return  err

--- a/DockerUtils.go
+++ b/DockerUtils.go
@@ -39,7 +39,7 @@ func startContainer(image string, containerConfig *container.Config, hostConfig 
 		return "", err
 	}
 
-	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
 
 	if err != nil {
 		return "", err

--- a/DockerUtils.go
+++ b/DockerUtils.go
@@ -39,7 +39,7 @@ func startContainer(image string, containerConfig *container.Config, hostConfig 
 		return "", err
 	}
 
-	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")
 
 	if err != nil {
 		return "", err

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,7 @@ RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/
 WORKDIR /go/src/benchmark
 COPY . .
 
-RUN go mod init
-RUN go get -d -v ./... 
 RUN go get -d -v github.com/pkg/errors
-RUN go get -d -v github.com/docker/docker@master
 RUN go build -v -o benchmark ./...
 
 ENTRYPOINT ["./benchmark"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/
 WORKDIR /go/src/benchmark
 COPY . .
 
-RUN go get -d -v github.com/pkg/errors
+RUN go get -d -v ./... github.com/pkg/errors
 RUN go build -v -o benchmark ./...
 
 ENTRYPOINT ["./benchmark"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/
 WORKDIR /go/src/benchmark
 COPY . .
 
-RUN go get -d -v ./... github.com/pkg/errors
+RUN go mod init
+RUN go get -d -v ./... 
+RUN go get -d -v github.com/pkg/errors
+RUN go get -d -v github.com/docker/docker@master
 RUN go build -v -o benchmark ./...
 
 ENTRYPOINT ["./benchmark"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module benchmark
+
+go 1.13
+
+require (
+        github.com/docker/docker v19.03.11
+)


### PR DESCRIPTION
add `go.mod` file to use a specific version of go docker client